### PR TITLE
fix: remove es6 module output for css

### DIFF
--- a/src/postcss/atomic-css-modules.ts
+++ b/src/postcss/atomic-css-modules.ts
@@ -185,22 +185,6 @@ const atomicCssModules = postcss.plugin<AtomicCssModulesOptions>(
       const jsonFilePath = cssFileName + ".json";
       await server.writeFile(jsonFilePath, JSON.stringify(json));
 
-      let es6ModuleContent = "";
-      const exported: string[] = [];
-
-      for (let key in json) {
-        if (Object.prototype.hasOwnProperty.call(json, key)) {
-          exported.push(key);
-          es6ModuleContent += `export const ${key} = ${JSON.stringify(
-            json[key]
-          )};\n`;
-        }
-      }
-
-      es6ModuleContent += `export default {${exported.join(",")}};`;
-
-      await server.writeFile(cssFileName + ".es6.js", es6ModuleContent);
-
       const typingsFilePath = path.join(
         path.dirname(cssFileName),
         "index.d.ts"

--- a/templates/atom_package.json.hbs
+++ b/templates/atom_package.json.hbs
@@ -2,6 +2,5 @@
   "name": "{{ packageName }}",
   "version": "0.0.1",
   "main": "module.css.json",
-  "module": "module.css.es6.js",
   "sideEffects": false
 }


### PR DESCRIPTION
The hypothesis was that we will get better bundle sizes with es6 module. Since webpack supports tree-shaking json, this is no longer required.