### PR TITLE
fix: exclude composes from hashable content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/atomic",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "description": "Atomic CSS composition for yarn workspaces",
   "repository": "utilitycss/atomic",
@@ -58,10 +58,7 @@
   },
   "lint-staged": {
     "linters": {
-      "*.js": [
-        "prettier --no-config --write",
-        "git add"
-      ],
+      "*.js": ["prettier --no-config --write", "git add"],
       "*.ts": [
         "prettier --no-config --write",
         "tslint -c tslint.json -p tsconfig.json --fix",

--- a/src/postcss/atomic-css-modules.ts
+++ b/src/postcss/atomic-css-modules.ts
@@ -28,6 +28,7 @@ function hashFunction(string: string, length: number): string {
 
 const generateHashableContent = (rule: Rule): string =>
   rule.nodes
+    .filter((d: Declaration) => d.prop !== "composes")
     .map((node: Declaration) => node.type + node.prop + node.value)
     .join(";");
 


### PR DESCRIPTION
@sylvesteraswin @boopathi 

Excluding `composes` declarations, we can avoid to change the hash of a class when the changes are only affecting composition (custom inlined css styles are not changed so the additional ccs modules generated class will have the same content).