### PR TITLE
feat: strip unused classes from json mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/atomic",
-  "version": "0.2.13",
+  "version": "0.3.0",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "description": "Atomic CSS composition for yarn workspaces",
   "repository": "utilitycss/atomic",


### PR DESCRIPTION
@sylvesteraswin @boopathi 

If classes are empty (hence stripped from global bundle) they will also be removed from the json mapping to avoid adding useless classes in the html.