### PR TITLE
fix: unpredictable hash for reexported electrons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/atomic",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "description": "Atomic CSS composition for yarn workspaces",
   "repository": "utilitycss/atomic",


### PR DESCRIPTION
atoms with the same class name as the used electron 
like:
```css
.myClass {
  electrons: (myClass);
}
```

in a non proxied package can result in nondeterministic hashing, due to caching of the first occurrence of that package/className combination.

to avoid that we should always use the electrons content to hash electon classes.