### PR TITLE
feat: single electrons hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/atomic",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "description": "Atomic CSS composition for yarn workspaces",
   "repository": "utilitycss/atomic",
@@ -57,10 +57,7 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "prettier --no-config --write",
-      "git add"
-    ],
+    "*.js": ["prettier --no-config --write", "git add"],
     "*.ts": [
       "prettier --no-config --write",
       "tslint -c tslint.json -p tsconfig.json --fix",

--- a/src/action/electrons-root.ts
+++ b/src/action/electrons-root.ts
@@ -1,0 +1,21 @@
+import postcss from "postcss";
+import path from "path";
+import AtomsServer from "../server";
+
+const electronsRoot = async ({ server }: { server: AtomsServer }) => {
+  const p = <{ [key: string]: any }>(
+    server.readFileSync(`pkg:${server.electronsModuleName}`)
+  );
+
+  const source = <string>(
+    server.readFileSync(
+      require.resolve(path.join(server.electronsModuleName, p.main))
+    )
+  );
+
+  const root = postcss.parse(source);
+
+  server.electronsRoot = root;
+};
+
+export default electronsRoot;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import chokidar from "chokidar";
+import postcss from "postcss";
 import Atom from "./atom";
 import generateDependencyGraph, { AtomGraph } from "./dependency-graph";
 import BuildAtomCssVisitor from "./visitor/build-atom-css";
@@ -6,6 +7,7 @@ import ConcatenateCSSVisitor from "./visitor/concatenate-css";
 import indexCssWatchChange from "./watch/index-css/change";
 import bundleAtomsAction from "./action/bundle-atoms";
 import electronsCssAction from "./action/electrons-css";
+import electronsRoot from "./action/electrons-root";
 import path from "path";
 import util from "util";
 import fs from "fs";
@@ -24,6 +26,7 @@ export default class AtomsServer {
   atomsFolder: string;
   electronsFolder: string;
   electronsModuleName: string;
+  electronsRoot: postcss.Root;
   utilityConfigPath: string;
   packageScope: string;
   bundleCSSPath: string;
@@ -154,6 +157,9 @@ export default class AtomsServer {
   }
 
   async run() {
+    console.log("START: building electrons root");
+    await electronsRoot({ server: this });
+    console.log("DONE: building electrons root");
     const indexCssWatcher = chokidar.watch(
       `packages/${this.atomsFolder}/**/index.css`
     );
@@ -164,6 +170,9 @@ export default class AtomsServer {
     console.log("START: building electrons css");
     await electronsCssAction({ electronsFolder: this.electronsFolder });
     console.log("DONE: building electrons css");
+    console.log("START: building electrons root");
+    await electronsRoot({ server: this });
+    console.log("DONE: building electrons root");
     console.log("START: building atoms css");
     console.time("build-atoms-css");
     await this.root.accept(


### PR DESCRIPTION
Close: https://github.com/utilitycss/atomic/issues/11

@sylvesteraswin @boopathi @ytanruengsri

- use rule body of single electrons to generate the hash
- remove package and rule name from the hashed string to allow deduping of identical classes 