### PR TITLE
fix: keep using name for hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utilitycss/atomic",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": "Andrea Moretti (@axyz) <axyzxp@gmail.com>",
   "description": "Atomic CSS composition for yarn workspaces",
   "repository": "utilitycss/atomic",

--- a/src/postcss/atomic-css-modules.ts
+++ b/src/postcss/atomic-css-modules.ts
@@ -28,31 +28,11 @@ function hashFunction(string: string, length: number): string {
 
 const CLASS_RE = /\.([\w-]+)/g;
 
-const generateHashableContent = (rule: Rule): string => {
-  let pseudo = "";
-  let media = "";
-
-  if (rule.selector && rule.selector.indexOf(":") !== -1) {
-    pseudo = `;${rule.selector.split(/:+/)[1]}`;
-  }
-
-  if (
-    rule.parent &&
-    rule.parent.type === "atrule" &&
-    rule.parent.name === "media"
-  ) {
-    media = `;${rule.parent.params}`;
-  }
-
-  return (
-    rule.nodes
-      .filter((d: Declaration) => d.prop !== "composes")
-      .map((node: Declaration) => node.type + node.prop + node.value)
-      .join(";") +
-    pseudo +
-    media
-  );
-};
+const generateHashableContent = (rule: Rule): string =>
+  rule.nodes
+    .filter((d: Declaration) => d.prop !== "composes")
+    .map((node: Declaration) => node.type + node.prop + node.value)
+    .join(";");
 
 const getElectronDefinition = (server: AtomsServer, name: any): string => {
   const definitionsMap = new Map();
@@ -202,7 +182,7 @@ const atomicCssModules = postcss.plugin<AtomicCssModulesOptions>(
 
       if (definitionsMap.has(name)) {
         const { key } = definitionsMap.get(name);
-        hash = hashFunction(definition, HASH_LENGTH);
+        hash = hashFunction(`${name}_${definition}`, HASH_LENGTH);
         trackClasses.set(key, hash);
       }
 
@@ -222,7 +202,7 @@ const atomicCssModules = postcss.plugin<AtomicCssModulesOptions>(
           // use electron hashes for proxied atoms
           const pkg = filename.match(importedElectronRE)[1];
           definition = getElectronDefinition(server, name);
-          hash = hashFunction(definition, HASH_LENGTH);
+          hash = hashFunction(`${name}_${definition}`, HASH_LENGTH);
           const key = `${pkg};${name}`;
           trackClasses.set(key, hash);
         } else {


### PR DESCRIPTION
@sylvesteraswin 

while avoiding using name would allow for aliases and smart deduping, we would need a way to identify how classes are used in combined selectors (e.g. > + :not(), etc...).

that can be investigated, but is quite complex and error prone, for now we can keep using the name as part of the hash.